### PR TITLE
Center logo on title page

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -1,6 +1,18 @@
         // Global variables
         let csvData = [];
-        let charts = {};
+let charts = {};
+
+// Load logo image as data URL
+async function loadLogo() {
+    const response = await fetch('Primary Branding Asset.png');
+    const blob = await response.blob();
+    return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsDataURL(blob);
+    });
+}
+
         
         // DOM elements
         const csvFile = document.getElementById('csvFile');
@@ -551,13 +563,16 @@
                 const orgName = document.getElementById('organizationName').value;
                 const reportPeriod = document.getElementById('reportPeriod').value;
                 const additionalNotes = document.getElementById('additionalNotes').value;
-                
+
+                const logo = await loadLogo();
+
                 // Generate report content
                 await createPDFContent(pdf, {
                     title: reportTitle,
                     organization: orgName,
                     period: reportPeriod,
-                    notes: additionalNotes
+                    notes: additionalNotes,
+                    logo: logo
                 });
                 
                 updateProgress(100, 'Report generation complete!');
@@ -593,12 +608,19 @@
             
             // Header
             pdf.setFillColor(0, 120, 212);
-            pdf.rect(0, 0, pageWidth, 40, 'F');
-            
-            // Title
+            const headerHeight = 55;
+            pdf.rect(0, 0, pageWidth, headerHeight, 'F');
+
+            if (config.logo) {
+                const logoWidth = 30;
+                const logoX = (pageWidth - logoWidth) / 2;
+                pdf.addImage(config.logo, 'PNG', logoX, 7, logoWidth, 30);
+            }
+
+            // Title below the logo
             pdf.setTextColor(255, 255, 255);
             pdf.setFontSize(24);
-            pdf.text(config.title, pageWidth / 2, 20, { align: 'center' });
+            pdf.text(config.title, pageWidth / 2, 45, { align: 'center' });
             
             // Organization
             if (config.organization) {
@@ -610,15 +632,16 @@
             
             // Info box
             pdf.setFillColor(248, 249, 250);
-            pdf.rect(20, 50, pageWidth - 40, 25, 'F');
-            
+            const infoBoxY = 70;
+            pdf.rect(20, infoBoxY, pageWidth - 40, 25, 'F');
+
             pdf.setFontSize(11);
-            pdf.text(`Period: ${config.period || 'Current'}`, pageWidth / 2, 58, { align: 'center' });
-            pdf.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth / 2, 67, { align: 'center' });
+            pdf.text(`Period: ${config.period || 'Current'}`, pageWidth / 2, infoBoxY + 8, { align: 'center' });
+            pdf.text(`Generated: ${new Date().toLocaleDateString()}`, pageWidth / 2, infoBoxY + 17, { align: 'center' });
             
             // Statistics
             const stats = generateStatistics();
-            let y = 85;
+            let y = infoBoxY + 35;
             
             pdf.setFontSize(14);
             pdf.setFont(undefined, 'bold');


### PR DESCRIPTION
## Summary
- reposition logo to the center of the PDF title page
- move report title below the logo and adjust subsequent layout

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687d9e983b0c83319db22088fb25c3f2