### PR TITLE
Center logo on title page

### DIFF
--- a/WindowsUpdateReport.html
+++ b/WindowsUpdateReport.html
@@ -69,7 +69,40 @@
                     
                     <div class="form-group">
                         <label for="organizationName">Organization Name</label>
-                        <input type="text" id="organizationName" placeholder="Your Organization" />
+                        <select id="organizationName">
+                            <option value="" disabled selected>Select organization...</option>
+                            <option value="Mann Consulting">Mann Consulting</option>
+                            <option value="Farmers Business Network Inc">Farmers Business Network Inc</option>
+                            <option value="Village Global">Village Global</option>
+                            <option value="Vintner's Daughter">Vintner's Daughter</option>
+                            <option value="Ostro Health">Ostro Health</option>
+                            <option value="Noria Energy">Noria Energy</option>
+                            <option value="MerQube">MerQube</option>
+                            <option value="Homebound">Homebound</option>
+                            <option value="JAZZ Venture Partners">JAZZ Venture Partners</option>
+                            <option value="Therabody">Therabody</option>
+                            <option value="FiscalNote">FiscalNote</option>
+                            <option value="01 Advisors">01 Advisors</option>
+                            <option value="Weaver Schlenger LLP">Weaver Schlenger LLP</option>
+                            <option value="Transmission Agency">Transmission Agency</option>
+                            <option value="EveryManJack">EveryManJack</option>
+                            <option value="Neo4j">Neo4j</option>
+                            <option value="Vanna Health">Vanna Health</option>
+                            <option value="Vote Solar">Vote Solar</option>
+                            <option value="Swoogo">Swoogo</option>
+                            <option value="Give2Asia">Give2Asia</option>
+                            <option value="KesselRun">KesselRun</option>
+                            <option value="Backflip">Backflip</option>
+                            <option value="Propel">Propel</option>
+                            <option value="Oshi Health">Oshi Health</option>
+                            <option value="Structure Properties">Structure Properties</option>
+                            <option value="Domino Data Lab">Domino Data Lab</option>
+                            <option value="Greylock">Greylock</option>
+                            <option value="Calm.com, Inc">Calm.com, Inc</option>
+                            <option value="Seneca">Seneca</option>
+                            <option value="Route 92 Medical, Inc">Route 92 Medical, Inc</option>
+                            <option value="International Orange">International Orange</option>
+                        </select>
                     </div>
                     
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- dynamically center the logo on the PDF title page
- adjust layout so organization and info box shift down accordingly
- extend header height so the blue background lines up with the logo
- use a dropdown of organization names to reduce naming errors

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687d9e983b0c83319db22088fb25c3f2