### PR TITLE
Add ARM64 filter for Intune App Repository

### DIFF
--- a/IntuneAppRepository.html
+++ b/IntuneAppRepository.html
@@ -16,12 +16,13 @@
       <div class="header">
         <div class="header-title">
           <svg
-            aria-hidden="true"
+            role="img"
             class="icon"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
+            <title>Intune App Repository Icon</title>
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -81,6 +82,11 @@
               <option value="publisher-asc">Publisher (A-Z)</option>
               <option value="publisher-desc">Publisher (Z-A)</option>
             </select>
+          </div>
+          <div class="filter-group">
+            <label for="armOnly">
+              <input type="checkbox" id="armOnly" /> ARM64 Only
+            </label>
           </div>
         </div>
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Browse and download common application installers for deployment through Intune.
 1. Visit https://luiserodz.github.io/theHAM/IntuneAppRepository.html
 2. Use the search box or filters to find an application
 3. Click the **x86/x64** or **ARM64** button to download the installer
+4. Use the copy icon to copy download links to the clipboard
+5. Check **ARM64 Only** to filter for applications with ARM packages
 
 ## Prerequisites
 

--- a/intune-app-repository.css
+++ b/intune-app-repository.css
@@ -220,6 +220,29 @@ body {
   margin-right: 0.5rem;
 }
 
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: #6b7280;
+  color: white;
+  border: none;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.copy-btn:hover {
+  background-color: #4b5563;
+}
+
+.copy-btn svg {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+}
+
 .no-results {
   background-color: white;
   border-radius: 0.5rem;

--- a/intune-app-repository.js
+++ b/intune-app-repository.js
@@ -31,6 +31,7 @@ function filterApplications() {
   const searchTerm = document.getElementById("searchInput").value.toLowerCase();
   const selectedCategory = document.getElementById("categorySelect").value;
   const selectedPublisher = document.getElementById("publisherSelect").value;
+  const armOnly = document.getElementById("armOnly").checked;
   currentSort = document.getElementById("sortSelect").value;
 
   filteredApps = applications.filter((app) => {
@@ -42,7 +43,8 @@ function filterApplications() {
     const matchesPublisher =
       selectedPublisher === "all" || app.publisher === selectedPublisher;
 
-    return matchesSearch && matchesCategory && matchesPublisher;
+    const matchesArm = !armOnly || app.armUrl;
+    return matchesSearch && matchesCategory && matchesPublisher && matchesArm;
   });
 
   renderApplications();
@@ -59,6 +61,7 @@ function resetFilters() {
   document.getElementById("categorySelect").value = "all";
   document.getElementById("publisherSelect").value = "all";
   document.getElementById("sortSelect").value = "name-asc";
+  document.getElementById("armOnly").checked = false;
   filterApplications();
 }
 function sortApps(arr) {
@@ -72,6 +75,30 @@ function sortApps(arr) {
     default:
       return arr.sort((a, b) => a.name.localeCompare(b.name));
   }
+}
+
+function createCopyButton(url, label) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "copy-btn";
+  btn.setAttribute("aria-label", `Copy ${label} link`);
+  btn.innerHTML = `
+        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 2h8a2 2 0 012 2v12a2 2 0 01-2 2H8a2 2 0 01-2-2V4a2 2 0 012-2zm-3 6H4a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-1"/>
+        </svg>
+        Copy
+    `;
+  btn.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      const original = btn.textContent;
+      btn.textContent = "Copied!";
+      setTimeout(() => (btn.textContent = original), 2000);
+    } catch (err) {
+      alert("Failed to copy link");
+    }
+  });
+  return btn;
 }
 
 function renderApplications() {
@@ -137,6 +164,7 @@ function renderApplications() {
             x86/x64
         `;
         buttonGroup.appendChild(downloadBtn);
+        buttonGroup.appendChild(createCopyButton(app.msiUrl, `${app.name} x86/x64`));
 
         // ARM button (if available)
         if (app.armUrl) {
@@ -153,6 +181,7 @@ function renderApplications() {
                 ARM64
             `;
           buttonGroup.appendChild(armBtn);
+          buttonGroup.appendChild(createCopyButton(app.armUrl, `${app.name} ARM64`));
         }
 
         appCard.appendChild(appName);
@@ -184,6 +213,9 @@ document.addEventListener("DOMContentLoaded", function () {
     .addEventListener("change", filterApplications);
   document
     .getElementById("sortSelect")
+    .addEventListener("change", filterApplications);
+  document
+    .getElementById("armOnly")
     .addEventListener("change", filterApplications);
 
   document


### PR DESCRIPTION
## Summary
- add "ARM64 Only" checkbox filter
- wire up filter logic in JavaScript
- update README with copy-link and ARM instructions

## Testing
- `node -c intune-app-repository.js`
- `tidy -qe IntuneAppRepository.html` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688809db60c08331aba97d75da752d94