### PR TITLE
Fix dependencies and preview scale

### DIFF
--- a/WindowsUpdateReport.html
+++ b/WindowsUpdateReport.html
@@ -173,7 +173,7 @@
     <div id="healthScoreText"></div>
 </div>
 
-<div class="chart-container">
+<div class="chart-container" style="height: 250px;">
     <div class="chart-title">Update Age Distribution</div>
     <canvas id="ageChart"></canvas>
 </div>

--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -857,9 +857,12 @@ async function generatePDFReport() {
     updateProgress(0, 'Initializing report generation...');
     
     try {
-        // Initialize jsPDF
-        const { jsPDF } = window.jspdf;
-        const pdf = new jsPDF('p', 'mm', 'a4');
+        // Initialize jsPDF from global
+        const jsPDFLib = window.jspdf ? window.jspdf.jsPDF : window.jsPDF;
+        if (!jsPDFLib) {
+            throw new Error('jsPDF library failed to load');
+        }
+        const pdf = new jsPDFLib('p', 'mm', 'a4');
         
         updateProgress(10, 'Creating report structure...');
         


### PR DESCRIPTION
## Summary
- remove vendored JS libraries
- load Chart.js and jsPDF from CDN again
- keep smaller Update Age Distribution preview
- guard against jsPDF failing to load

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688910637e748331948e124cca00d6d2