### PR TITLE
Restore CDN libraries for Windows Update Report

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -892,11 +892,12 @@ async function generatePDFReport() {
         downloadLink.href = url;
         downloadLink.download = `${reportTitle.replace(/[^a-z0-9]/gi, '_')}_${new Date().toISOString().slice(0, 10)}.pdf`;
         
-        // Show download section
+        // Show download section and bring it into view
         downloadSection.classList.add('show');
         statusSection.classList.remove('show');
-        
-        // Focus download section without forcing scroll
+        downloadSection.scrollIntoView({ behavior: 'smooth' });
+
+        // Focus download section for accessibility
         downloadSection.focus();
         
     } catch (error) {


### PR DESCRIPTION
## Summary
- revert bundling of jsPDF, AutoTable and Chart.js libraries
- keep Windows Update Report loading them from CDNs
- auto-scroll to the download section after PDF generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688916716f948331ab4a45c151c3a45e