### PR TITLE
Add persistent download button for Windows Update report

### DIFF
--- a/WindowsUpdateReport.html
+++ b/WindowsUpdateReport.html
@@ -155,9 +155,14 @@
                     <textarea id="additionalNotes" rows="3" placeholder="Add any custom notes or observations for this report period..."></textarea>
                 </div>
 
-                <button class="btn btn-success" id="generateReport" disabled>
-                    🎯 Generate PDF Report
-                </button>
+                <div class="action-buttons">
+                    <button class="btn btn-success" id="generateReport" disabled>
+                        🎯 Generate PDF Report
+                    </button>
+                    <a href="#" id="downloadLink" class="btn btn-success disabled">
+                        <span role="img" aria-label="download">📥</span> Download PDF Report
+                    </a>
+                </div>
             </div>
 
             <!-- Charts Preview Section -->
@@ -213,9 +218,6 @@
                 <div class="alert alert-success">
                     <span role="img" aria-label="check mark">✅</span> Report generated successfully!
                 </div>
-                <a href="#" id="downloadLink" class="btn btn-success">
-                    <span role="img" aria-label="download">📥</span> Download PDF Report
-                </a>
             </div>
         </main>
     </div>

--- a/windows-update-report.css
+++ b/windows-update-report.css
@@ -115,6 +115,12 @@
             transform: none;
         }
 
+        .btn.disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
         .data-preview {
             background: white;
             border: 1px solid #dee2e6;
@@ -218,6 +224,12 @@
             outline: none;
             border-color: #0078d4;
             box-shadow: 0 0 0 3px rgba(0, 120, 212, 0.1);
+        }
+
+        .action-buttons {
+            display: flex;
+            gap: 10px;
+            align-items: center;
         }
 
         .checkbox-group {

--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -31,12 +31,14 @@ const chartsPreview = document.getElementById('chartsPreview');
 const statusSection = document.getElementById('statusSection');
 const downloadSection = document.getElementById('downloadSection');
 const generateReportBtn = document.getElementById('generateReport');
+const downloadLink = document.getElementById('downloadLink');
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Windows Update Report Generator initializing...');
     setupEventListeners();
     loadSavedPreferences();
+    downloadLink.classList.add('disabled');
     console.log('Initialization complete');
 });
 
@@ -867,6 +869,9 @@ async function generatePDFReport() {
     statusSection.classList.add('show');
     // Hide any previous download section before starting a new run
     downloadSection.classList.remove('show');
+    downloadLink.classList.add('disabled');
+    downloadLink.removeAttribute('href');
+    downloadLink.removeAttribute('download');
     statusSection.scrollIntoView({ behavior: 'smooth' });
     updateProgress(0, 'Initializing report generation...');
     
@@ -902,18 +907,17 @@ async function generatePDFReport() {
         // Create download link
         const pdfBlob = pdf.output('blob');
         const url = URL.createObjectURL(pdfBlob);
-        const downloadLink = document.getElementById('downloadLink');
         downloadLink.href = url;
         downloadLink.download = `${reportTitle.replace(/[^a-z0-9]/gi, '_')}_${new Date().toISOString().slice(0, 10)}.pdf`;
-        
+        downloadLink.classList.remove('disabled');
+
         // Show download section and bring it into view
         downloadSection.classList.add('show');
         statusSection.classList.remove('show');
-        downloadLink.style.display = 'inline-block';
-        downloadSection.scrollIntoView({ behavior: 'smooth' });
+        downloadLink.scrollIntoView({ behavior: 'smooth' });
 
-        // Focus download section for accessibility
-        downloadSection.focus();
+        // Focus download link for accessibility
+        downloadLink.focus();
         
     } catch (error) {
         console.error('Error generating PDF:', error);


### PR DESCRIPTION
## Summary
- keep Download PDF button visible next to Generate button
- disable download button until a report is generated
- show download progress and enable button after generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68898669c6448331a651680555be7178