### PR TITLE
Fix progress bar regression in PDF generator

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -932,6 +932,10 @@ async function createPDFContent(pdf, config) {
     const pageMargin = 20; // uniform left/right margin
     const usableWidth = pageWidth - pageMargin * 2;
     let currentPage = 1;
+
+    // Dimensions used when embedding chart images
+    const chartWidth = pageWidth - pageMargin * 2;
+    const chartHeight = 60;
     
     // Standardized font sizes
     const FONT_SIZES = {


### PR DESCRIPTION
## Summary
- reintroduce missing `chartWidth` and `chartHeight` variables for PDF chart rendering

## Testing
- `node -c windows-update-report.js`


------
https://chatgpt.com/codex/tasks/task_e_688a1e2b51c08331b1be31e04a20da8e