### PR TITLE
Increase spacing under logo on report cover

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -975,7 +975,8 @@ async function createPDFContent(pdf, config) {
         const logoHeight = (props.height / props.width) * logoWidth;
         const logoX = (pageWidth - logoWidth) / 2;
         pdf.addImage(config.logo, 'PNG', logoX, headerY, logoWidth, logoHeight);
-        headerY += logoHeight + 4; // Reduced spacing
+        // Increase spacing below the logo so the title aligns more evenly with the organization name
+        headerY += logoHeight + 8;
     }
 
     pdf.setTextColor(255, 255, 255);


### PR DESCRIPTION
## Summary
- tweak vertical spacing under the logo in the PDF export so the title lines up better with the organization name

## Testing
- `node --check windows-update-report.js`


------
https://chatgpt.com/codex/tasks/task_e_688a3998c52883318433ae6a2e976cad