### PR TITLE
Remove tabs from WindowsUpdateReport UI

### DIFF
--- a/WindowsUpdateReport.html
+++ b/WindowsUpdateReport.html
@@ -15,12 +15,6 @@
         </header>
 
         <main class="main-content">
-            <!-- Navigation Tabs -->
-            <div class="nav-tabs">
-                <div class="nav-tab active">Upload Data</div>
-                <div class="nav-tab">Configure Report</div>
-                <div class="nav-tab">Preview & Generate</div>
-            </div>
 
             <!-- Info Alert -->
             <div class="alert alert-info">

--- a/windows-update-report.css
+++ b/windows-update-report.css
@@ -416,38 +416,6 @@
             background-color: #fff3cd;
         }
 
-        /* Intune-style Navigation Tabs */
-        .nav-tabs {
-            display: flex;
-            background: #f8f9fa;
-            border-bottom: 1px solid #dee2e6;
-            margin: -30px -30px 30px;
-            padding: 0 30px;
-        }
-
-        .nav-tab {
-            flex: 0 0 auto;
-            padding: 15px 20px;
-            text-align: center;
-            background: #f8f9fa;
-            border: none;
-            cursor: pointer;
-            font-size: 14px;
-            font-weight: 500;
-            color: #495057;
-            transition: all 0.3s ease;
-            border-bottom: 3px solid transparent;
-        }
-
-        .nav-tab:hover {
-            background: #e9ecef;
-        }
-
-        .nav-tab.active {
-            background: white;
-            color: #0078d4;
-            border-bottom-color: #0078d4;
-        }
 
         /* Section Headers */
         .section-title {

--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -82,22 +82,6 @@ function setupEventListeners() {
         element.addEventListener('change', saveFormData);
     });
 
-    // Tab navigation
-    document.querySelectorAll('.nav-tab').forEach((tab, index) => {
-        tab.addEventListener('click', () => {
-            document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
-            tab.classList.add('active');
-
-            // Simple tab switching logic without automatic scrolling
-            if (index === 0) {
-                uploadSection.focus();
-            } else if (index === 1) {
-                reportOptions.focus();
-            } else if (index === 2) {
-                chartsPreview.focus();
-            }
-        });
-    });
 }
 
 function handleFileUpload() {


### PR DESCRIPTION
## Summary
- remove the navigation tab bar from WindowsUpdateReport
- drop related CSS rules and JS logic

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a3be0bc288331a8d758756e73d08f