### PR TITLE
Fix missing report period in Windows Update PDF

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -929,6 +929,11 @@ async function createPDFContent(pdf, config) {
     if (config.organization) {
         pdf.setFontSize(FONT_SIZES.subtitle);
         pdf.text(config.organization, pageWidth / 2, headerY, { align: 'center' });
+        headerY += 6; // space for optional period line
+    }
+    if (config.period) {
+        pdf.setFontSize(FONT_SIZES.small);
+        pdf.text(`Report Period: ${config.period}`, pageWidth / 2, headerY, { align: 'center' });
     }
 
     pdf.setTextColor(0, 0, 0);


### PR DESCRIPTION
## Summary
- show the report period on the PDF title page

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688a73faead48331b7c20896891732f0