### PR TITLE
Fix report period spacing

### DIFF
--- a/windows-update-report.js
+++ b/windows-update-report.js
@@ -921,7 +921,8 @@ async function createPDFContent(pdf, config) {
 
     // Header
     pdf.setFillColor(0, 120, 212);
-    const headerHeight = 50; // Reduced from 60
+    // Slightly taller header so the report period text has padding
+    const headerHeight = 60; // Increased from 50
     pdf.rect(0, 0, pageWidth, headerHeight, 'F');
 
     let headerY = 8; // Reduced from 10


### PR DESCRIPTION
## Summary
- add more padding for the title page header so the report period text is fully inside the blue banner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a8c7eabb883318fc9eddcd97eb49d