### PR TITLE
fix invalid variable reference in Winget update script

### DIFF
--- a/Winget_Update_All
+++ b/Winget_Update_All
@@ -993,7 +993,7 @@ if ($updates.Count -eq 0) {
 $msg = "Found $($updates.Count) available update(s)"
 Write-Log -LogLevel 'INFO' -Message $msg
 if (-not $script:SilentMode) {
-    Write-Host "`n$msg:" -ForegroundColor Cyan
+    Write-Host "`n${msg}:" -ForegroundColor Cyan
     foreach ($update in $updates) {
         Write-Host "  - $($update.Name) ($($update.CurrentVersion) -> $($update.AvailableVersion))" -ForegroundColor White
     }


### PR DESCRIPTION
## Summary
- fix variable expansion when displaying available updates in `Winget_Update_All`

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6892673550248331a1f264fe0a6ddc2d