### PR TITLE
Fix Winget_Update_All parameter syntax

### DIFF
--- a/Winget_Update_All
+++ b/Winget_Update_All
@@ -3,13 +3,13 @@
 
 param(
     [Parameter()]
-    [int]$WaitTimeMinutes = 5,
+    [int]$WaitTimeMinutes = 5
     [Parameter()]
-    [switch]$ForceUpdate,
+    [switch]$ForceUpdate
     [Parameter()]
-    [switch]$SilentMode,
+    [switch]$SilentMode
     [Parameter()]
-    [switch]$AutoRun,
+    [switch]$AutoRun
     [Parameter()]
     [string]$ConfigPath = "$env:ProgramData\WinGetUpdater\config.json"
 )


### PR DESCRIPTION
## Summary
- fix `param` block by removing trailing commas

## Testing
- `pwsh -NoLogo -NoProfile -Command "& './Winget_Update_All'"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689269bd7e508331ab534f6606e2de31