### PR TITLE
Fix overflowing assignment modal in Intune Policy Manager

### DIFF
--- a/IntunePolicyManager.html
+++ b/IntunePolicyManager.html
@@ -559,21 +559,22 @@
             display: none;
             position: fixed;
             z-index: 1000;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
+            inset: 0;
             background-color: rgba(0, 0, 0, 0.5);
             animation: fadeIn 0.3s ease;
+            overflow-y: auto;
+            padding: 2rem 1rem;
         }
 
         .modal-content {
             background-color: white;
-            margin: 10% auto;
+            margin: auto;
             padding: 20px;
             border-radius: 8px;
-            width: 80%;
+            width: 100%;
             max-width: 500px;
+            max-height: calc(100vh - 4rem);
+            overflow-y: auto;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             animation: slideIn 0.3s ease;
         }


### PR DESCRIPTION
## Summary
- allow the confirmation modal overlay to scroll independently of the viewport
- constrain modal content height and enable internal scrolling to prevent content from being cut off

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee798b9e083319bd6105b74764949